### PR TITLE
I've updated qrcode.decode to optionally take a canvas reference

### DIFF
--- a/src/QRCode.js
+++ b/src/QRCode.js
@@ -32,13 +32,13 @@ qrcode.decode = function(src){
 	{
 		var canvas_qr;
         // If the object passed in appears to be a canvas then lets use that
-        if (src.getContext)
+        if (arguments.length == 0) 
         {
-            canvas_qr = src;
+            canvas_qr = document.getElementById("qr-canvas");
         }
         else
         {
-            canvas_qr = document.getElementById("qr-canvas");
+            canvas_qr = src;
         }
 		var context = canvas_qr.getContext('2d');
 		qrcode.width = canvas_qr.width;

--- a/src/QRCode.js
+++ b/src/QRCode.js
@@ -28,9 +28,18 @@ qrcode.callback = null;
 
 qrcode.decode = function(src){
 	
-	if(arguments.length==0)
+	if(arguments.length==0 || src.getContext)
 	{
-		var canvas_qr = document.getElementById("qr-canvas");
+		var canvas_qr;
+        // If the object passed in appears to be a canvas then lets use that
+        if (src.getContext)
+        {
+            canvas_qr = src;
+        }
+        else
+        {
+            canvas_qr = document.getElementById("qr-canvas");
+        }
 		var context = canvas_qr.getContext('2d');
 		qrcode.width = canvas_qr.width;
 		qrcode.height = canvas_qr.height;


### PR DESCRIPTION
It's not always convenient to have a canvas with a set id so I made qrcode.decode accept a reference to a canvas object instead.

Oh, and thanks for writting this!!
