### PR TITLE
Camcanvas flash is gone - let's simply get the camera from the video tag

### DIFF
--- a/src/camcanvas.js
+++ b/src/camcanvas.js
@@ -1,0 +1,120 @@
+var requestAnimationFrame = window.requestAnimationFrame || window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame || window.msRequestAnimationFrame;
+window.requestAnimationFrame = requestAnimationFrame;
+
+var v, canvas, gCtx, pixelOperationFunction=passEmboss;
+var backBuffer = document.createElement('canvas');
+var bCtx = backBuffer.getContext('2d');
+
+function setFunction (fName) { 
+	pixelOperationFunction=fName;
+} 
+
+function init() {
+  v = document.getElementById('v');
+  canvas = document.getElementById('qr-canvas');
+  gCtx = canvas.getContext('2d');
+  navigator.webkitGetUserMedia({video:true}, callbackStreamIsReady);
+}
+
+function callbackStreamIsReady(stream) {
+  v.src = URL.createObjectURL(stream);
+  v.play();
+  window.requestAnimationFrame(draw);
+}
+
+function draw() {
+  var w = canvas.clientWidth;
+  var h = canvas.clientHeight;
+  backBuffer.width = w;
+  backBuffer.height = h;
+  bCtx.drawImage(v, 0, 0, w, h);
+  pixelOperationFunction(w,h);
+  window.requestAnimationFrame(draw);
+}
+
+function passInverse(w,h) { 
+   var pixels = bCtx.getImageData(0, 0, w, h);
+   var pixelData = pixels.data;
+   for (var i = 0; i < pixelData.length; i+=4) { 
+     //pixelData.data[i+0]=r;
+     var rr = pixelData[i+0];
+     var gg = pixelData[i+1];
+     var bb = pixelData[i+2];
+     var average = parseInt((rr+gg+bb)/3);
+
+     var diffMedia = 255-average; 
+     average = diffMedia; 
+
+     pixelData[parseInt(i+0)]=average;
+     pixelData[parseInt(i+1)]=average;
+     pixelData[parseInt(i+2)]=average;
+     pixelData[parseInt(i+3)]=255;
+   } 
+   pixels.data = pixelData;
+   gCtx.putImageData(pixels, 0, 0);
+} 
+
+function passGray(w,h) { 
+   var pixels = bCtx.getImageData(0, 0, w, h);
+   var pixelData = pixels.data;
+   for (var i = 0; i < pixelData.length; i+=4) { 
+     //pixelData.data[i+0]=r;
+     var rr = pixelData[i+0];
+     var gg = pixelData[i+1];
+     var bb = pixelData[i+2];
+
+     var average = parseInt((rr+gg+bb)/3);
+     pixelData[parseInt(i+0)]=average;
+     pixelData[parseInt(i+1)]=average;
+     pixelData[parseInt(i+2)]=average;
+     pixelData[parseInt(i+3)]=255;
+   } 
+   pixels.data = pixelData;
+   gCtx.putImageData(pixels, 0, 0);
+} 
+
+function passNormal(w,h) { 
+   var pixels = bCtx.getImageData(0, 0, w, h);
+   gCtx.putImageData(pixels, 0, 0);
+} 
+	
+function passRed(w,h) { 
+   var pixels = bCtx.getImageData(0, 0, w, h);
+   var pixelData = pixels.data;
+   for (var i = 0; i < pixelData.length; i+=4) { 
+     //pixelData.data[i+0]=r;
+     pixelData[parseInt(i+1)]=0;
+     pixelData[parseInt(i+2)]=0;
+     pixelData[parseInt(i+3)]=255;
+   } 
+   pixels.data = pixelData;
+   gCtx.putImageData(pixels, 0, 0);
+} 
+				
+function passEmboss(w,h) { 
+   var pixels = bCtx.getImageData(0, 0, w, h);
+   var pixelData = pixels.data;
+   for (var i = 0; i < pixelData.length; i+=4) { 
+     //pixelData.data[i+0]=r;
+     var rr = pixelData[i+0];
+     var gg = pixelData[i+1];
+     var bb = pixelData[i+2];
+     var average = parseInt((rr+gg+bb)/3);
+     if(i>7) { 
+       mOld = pixelData[i-8+0];
+       mOld = pixelData[i-8+1];
+       mOld = pixelData[i-8+2];
+       var diffMedia = 255-average; 
+       average = diffMedia; 
+
+       mNew = parseInt((mOld + average )/ 2);
+
+       pixelData[i-8+0]=mNew;
+       pixelData[i-8+1]=mNew;
+       pixelData[i-8+2]=mNew;
+     }
+   } 
+   pixels.data = pixelData;
+   gCtx.putImageData(pixels, 0, 0);
+} 
+

--- a/src/test.html
+++ b/src/test.html
@@ -24,51 +24,9 @@
 <script type="text/javascript" src="alignpat.js"></script>
 <script type="text/javascript" src="databr.js"></script>
 
+<script type="text/javascript" src="camcanvas.js"></script>
+
 <script type="text/javascript">
-var gCtx = null;
-	var gCanvas = null;
-
-	var imageData = null;
-	var ii=0;
-	var jj=0;
-	var c=0;
-	
-	
-function dragenter(e) {
-  e.stopPropagation();
-  e.preventDefault();
-}
-
-function dragover(e) {
-  e.stopPropagation();
-  e.preventDefault();
-}
-function drop(e) {
-  e.stopPropagation();
-  e.preventDefault();
-
-  var dt = e.dataTransfer;
-  var files = dt.files;
-
-  handleFiles(files);
-}
-
-function handleFiles(f)
-{
-	var o=[];
-	for(var i =0;i<f.length;i++)
-	{
-	  var reader = new FileReader();
-
-      reader.onload = (function(theFile) {
-        return function(e) {
-          qrcode.decode(e.target.result);
-        };
-      })(f[i]);
-
-      // Read in the image file as a data URL.
-      reader.readAsDataURL(f[i]);	}
-}
 	
 function read(a)
 {
@@ -77,73 +35,24 @@ function read(a)
 	
 function load()
 {
-	initCanvas(640,480);
+	init();
 	qrcode.callback = read;
-	qrcode.decode("meqrthumb.png");
 }
 
-function initCanvas(ww,hh)
-	{
-		gCanvas = document.getElementById("qr-canvas");
-		gCanvas.addEventListener("dragenter", dragenter, false);  
-		gCanvas.addEventListener("dragover", dragover, false);  
-		gCanvas.addEventListener("drop", drop, false);
-		var w = ww;
-		var h = hh;
-		gCanvas.style.width = w + "px";
-		gCanvas.style.height = h + "px";
-		gCanvas.width = w;
-		gCanvas.height = h;
-		gCtx = gCanvas.getContext("2d");
-		gCtx.clearRect(0, 0, w, h);
-		imageData = gCtx.getImageData( 0,0,320,240);
-	}
-
-	function passLine(stringPixels) { 
-		//a = (intVal >> 24) & 0xff;
-
-		var coll = stringPixels.split("-");
-	
-		for(var i=0;i<320;i++) { 
-			var intVal = parseInt(coll[i]);
-			r = (intVal >> 16) & 0xff;
-			g = (intVal >> 8) & 0xff;
-			b = (intVal ) & 0xff;
-			imageData.data[c+0]=r;
-			imageData.data[c+1]=g;
-			imageData.data[c+2]=b;
-			imageData.data[c+3]=255;
-			c+=4;
-		} 
-
-		if(c>=320*240*4) { 
-			c=0;
-      			gCtx.putImageData(imageData, 0,0);
-		} 
- 	} 
-
         function captureToCanvas() {
-		flash = document.getElementById("embedflash");
-		flash.ccCapture();
-		qrcode.decode();
+		    qrcode.decode();
         }
 </script>
 
 </head>
 
 <body onload="load()">
-    <div class="container">
-	
-  	<object  id="iembedflash" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=7,0,0,0" width="320" height="240">
-  		<param name="movie" value="camcanvas.swf" />
-  		<param name="quality" value="high" />
-		<param name="allowScriptAccess" value="always" />
-  		<embed  allowScriptAccess="always"  id="embedflash" src="camcanvas.swf" quality="high" width="320" height="240" type="application/x-shockwave-flash" pluginspage="http://www.macromedia.com/go/getflashplayer" mayscript="true"  />
-    </object>
-	
-    </div>
+
+<video id="v" width="320" height="240"></video>
+<canvas id="qr-canvas" width="320" height="240"></canvas>
+
 <button onclick="captureToCanvas()">Capture</button><br>
-<canvas id="qr-canvas" width="640" height="480"></canvas>
+
 </body>
 
 </html>


### PR DESCRIPTION
I am the developer of the old camcanvas flash to JS  and now we have the video tag with the media support.
