### PR TITLE
remove Array.prototype.remove function

### DIFF
--- a/src/qrcode.js
+++ b/src/qrcode.js
@@ -275,9 +275,3 @@ function URShift( number,  bits)
 		return (number >> bits) + (2 << ~bits);
 }
 
-
-Array.prototype.remove = function(from, to) {
-  var rest = this.slice((to || from) + 1 || this.length);
-  this.length = from < 0 ? this.length + from : from;
-  return this.push.apply(this, rest);
-};


### PR DESCRIPTION
beware, for example this function becomes an array element in firefox.
if it is really necessary, don't declare on a native object.
moreover, I don't see the usefulness of this function in this project.
