### PR TITLE
Allow cross-origin canvas image

### DIFF
--- a/src/qrcode.js
+++ b/src/qrcode.js
@@ -44,6 +44,7 @@ qrcode.decode = function(src){
     else
     {
         var image = new Image();
+        image.crossOrigin = "Anonymous";
         image.onload=function(){
             //var canvas_qr = document.getElementById("qr-canvas");
             var canvas_qr = document.createElement('canvas');


### PR DESCRIPTION
Fixes the issue where reading image from canvas will result in error of having a `tainted` image.