### PR TITLE
Set crossOrigin to null when src is from data: URI or blob: URI for Mobile Safari

### DIFF
--- a/src/qrcode.js
+++ b/src/qrcode.js
@@ -44,7 +44,7 @@ qrcode.decode = function(src){
     else
     {
         var image = new Image();
-        image.crossOrigin = "Anonymous";
+        image.crossOrigin = src.match(/^(data|blob):/i) != null ? null : "Anonymous";
         image.onload=function(){
             //var canvas_qr = document.getElementById("qr-canvas");
             var canvas_qr = document.createElement('canvas');


### PR DESCRIPTION
When set data: URI or blob: URI and also set `crossOrigin = "Anonymus"` will get error message of `Cross-origin image load denied by Cross-Origin Resource Sharing policy.` from Mobile Safari, set null instead Anonymous in this scenario.