### PR TITLE
Fix Cross-origin image load in Safari

### DIFF
--- a/src/qrcode.js
+++ b/src/qrcode.js
@@ -44,7 +44,10 @@ qrcode.decode = function(src){
     else
     {
         var image = new Image();
-        image.crossOrigin = "Anonymous";
+       // fixes Cross-origin image load denied by Cross-Origin Resource Sharing policy in Safari
+        if(src.indexOf('data:image') !== 0) {
+            image.crossOrigin = 'Anonymous';
+        }
         image.onload=function(){
             //var canvas_qr = document.getElementById("qr-canvas");
             var canvas_qr = document.createElement('canvas');


### PR DESCRIPTION
This PR fixes the "Cross-origin image load denied by Cross-Origin Resource Sharing policy" error in Safari